### PR TITLE
Zed theme improvements

### DIFF
--- a/extra/zed/themes/sakura.json
+++ b/extra/zed/themes/sakura.json
@@ -123,7 +123,10 @@
         "minimap.thumb.border": "#161616",
         "version_control.added": "#6f9354",
         "version_control.deleted": "#c96c7f",
-        "version_control.modified": "#bb8c6e"
+        "version_control.modified": "#bb8c6e",
+        "created": "#6f9354",
+        "deleted": "#c96c7f",
+        "modified": "#bb8c6e"
       }
     }
   ],

--- a/extra/zed/themes/sakura_light.json
+++ b/extra/zed/themes/sakura_light.json
@@ -123,7 +123,10 @@
         "minimap.thumb.border": "#f6f0f4",
         "version_control.added": "#3f805a",
         "version_control.deleted": "#c44754",
-        "version_control.modified": "#a8783e"
+        "version_control.modified": "#a8783e",
+        "created": "#3f805a",
+        "deleted": "#c44754",
+        "modified": "#a8783e"
       }
     }
   ],


### PR DESCRIPTION
Files that are git tracked are now colored in a more readable way that follow the git signs rules

Before:
<img width="175" height="69" alt="image" src="https://github.com/user-attachments/assets/d224471d-0016-4afa-95e3-8141907245cf" />

After:
<img width="179" height="62" alt="image" src="https://github.com/user-attachments/assets/f7501fee-02fa-48ed-842e-0862a704c949" />
